### PR TITLE
Fix: Use explicit imports for ProtoBuf messages

### DIFF
--- a/trading.py
+++ b/trading.py
@@ -17,11 +17,26 @@ except ImportError:
 # Imports from spotware/OpenApiPy
 try:
     from ctrader_open_api import Client, Protobuf, TcpProtocol, EndPoints
-    from ctrader_open_api.messages.OpenApiCommonMessages_pb2 import *
-    from ctrader_open_api.messages.OpenApiMessages_pb2 import *
-    # Explicitly import potentially problematic names if wildcard doesn't catch them or for clarity
-    from ctrader_open_api.messages.OpenApiMessages_pb2 import ProtoOAGetAccountListReq, ProtoOAGetAccountListRes
-    from ctrader_open_api.messages.OpenApiModelMessages_pb2 import *
+    from ctrader_open_api.messages.OpenApiCommonMessages_pb2 import (
+        ProtoOAPayloadType, ProtoOAErrorCode, ProtoHeartbeatEvent,
+        ProtoOATraderUpdatedEvent, ProtoOASpotEvent, ProtoOAExecutionEvent, # Assuming these are common enough
+        ProtoOATradeSide # Enum for order placement
+        # Add other common enums if needed, e.g. ProtoOAOrderType
+    )
+    from ctrader_open_api.messages.OpenApiMessages_pb2 import (
+        ProtoOAApplicationAuthReq, ProtoOAApplicationAuthRes,
+        ProtoOAAccountAuthReq, ProtoOAAccountAuthRes,
+        ProtoOAGetAccountListReq, ProtoOAGetAccountListRes,
+        ProtoOAGetTraderReq, ProtoOATraderRes,
+        ProtoOASubscribeSpotsReq, ProtoOASubscribeSpotsRes, # Assuming response exists
+        ProtoOANewOrderReq, # Assuming response is ProtoOAExecutionEvent
+        ProtoPingReq, ProtoPingRes,
+        ProtoOAErrorRes
+    )
+    from ctrader_open_api.messages.OpenApiModelMessages_pb2 import (
+        ProtoOATrader # Model used in ProtoOATraderRes
+        # Add other models if directly used, e.g. ProtoOAOrder, ProtoOAPosition
+    )
     USE_OPENAPI_LIB = True
 except ImportError:
     print("ctrader-open-api library not found. Please install it. Running in mock mode.")


### PR DESCRIPTION
Replace wildcard imports from ctrader_open_api.messages with explicit imports for all used ProtoOA message classes (e.g., ProtoOAApplicationAuthReq, ProtoOAGetAccountListRes, ProtoOATrader, etc.).

This aims to resolve NameErrors encountered if wildcard imports were not behaving as expected or if the library wasn't fully available at parse time for type hints after a failed initial import.

## Summary by Sourcery

Use explicit imports for protobuf message classes in trading.py to ensure all needed messages are available and prevent NameErrors caused by wildcard imports.

Bug Fixes:
- Resolve NameErrors for ProtoBuf messages when wildcard imports fail or the library isn’t fully available at parse time.

Enhancements:
- Replace wildcard imports with explicit imports of required ProtoBuf message classes from ctrader_open_api.